### PR TITLE
Queue debugging

### DIFF
--- a/Simulators/FlowSimulator.py
+++ b/Simulators/FlowSimulator.py
@@ -176,8 +176,6 @@ class FlowSimulator:
         if len(peakTraffic) > len(traffic):
             return False
 
-        print(peakTraffic)
-
         flowResult = [0, 0, []]
         for i in range(0, len(traffic)):
             flowResult = self.__setNormalFlows(flowResult[0], flowResult[2], traffic[i])

--- a/Simulators/MethodsSimulator.py
+++ b/Simulators/MethodsSimulator.py
@@ -62,6 +62,8 @@ class MethodsSimulator:
     def queueAllocation(self, testMethod): 
         testMethod.schedulerData[3] = 0
 
+        sum_teste = 0
+
         for flow in testMethod.schedulerData[2]:
             if len(flow) == 4:
                 flow.append(1)
@@ -72,6 +74,10 @@ class MethodsSimulator:
                     testMethod.schedulerData[3] += flow[1]
                     continue
 
+            sum_teste += flow[1]
+
+            print(flow[4])
+
             if isinstance(testMethod, DeMONS):
                 testMethod.selectiveFlowAllocation(flow[2], flow[0], flow[1], flow[3], flow[4])
             elif isinstance(testMethod, VGuard):
@@ -79,6 +85,7 @@ class MethodsSimulator:
 
         testMethod.schedulerData[1] = 0
         testMethod.schedulerData[2] = []  
+        print("---> ", sum_teste)
 
 
     def lowTunnelSatisfaction(self, testMethod):
@@ -308,7 +315,6 @@ class MethodsSimulator:
     # filterMechanism: filter mechanism ID for the low priority tunnel [0: Method Std; 1: Token Bucket Policer; 2: Leaky Bucket Shaper; 3..: Leaky Bucket Shaper + Priority Filter]
     # filterPolicy: filter policy ID (sometimes not required) [0: Restrictive; 1: Medium; 2: Permissive]
     #TODO: A FILA NÃO ESTÁ SENDO 100% APROVEITADA EM CENÁRIOS DE SOBRECARGA -- VERIFICAR O QUE PODE ESTAR GERANDO ESSE FENOMENO
-    #TODO: OS CANAIS NÃO ESTÃO SENDO 100% APROVEITADOS -- VERIFICAR O QUE PODE ESTAR CAUSANDO ESSE FENOMENO
     def simulationBySecond(self, trafficFilePath, testMethod, reportInterval = 1, filterMechanism = 0, filterPolicy = 0, outputFile = None):
         seconds = 1
         inputData = open(trafficFilePath, 'r')
@@ -332,8 +338,18 @@ class MethodsSimulator:
                     seconds += 1
                 else:
 
+                    print(testMethod.tunnelLowUse)
+                    print(testMethod.tunnelHighUse, "\n--")
+
                     #Inserting flows from the queue into the low-priority tunnel to compete for resources
                     self.queueAllocation(testMethod)
+
+                    if seconds == 4:
+                        self.removeDeadFlows(testMethod)
+
+                        print(testMethod.tunnelLowUse)
+                        print(testMethod.tunnelHighUse, "\n")
+                        exit()
 
                     nonQueuedData = len(testMethod.tunnelLowFlows)
                     testMethod.tunnelLowFilter(filterMechanism, filterPolicy)

--- a/Simulators/MethodsSimulator.py
+++ b/Simulators/MethodsSimulator.py
@@ -47,22 +47,26 @@ class MethodsSimulator:
 
 
     def removeDeadFlows(self, testMethod):
+        oldFlows = []
         for flow in testMethod.tunnelHighFlows:
             if len(flow) == 5:
                 testMethod.tunnelHighUse -= flow[1]
                 testMethod.tunnelHighSum -= flow[0]
-                testMethod.tunnelHighFlows.remove(flow)
+                oldFlows.append(flow)
+        for flow in oldFlows:
+            testMethod.tunnelHighFlows.remove(flow)
+        
+        oldFlows = []
         for flow in testMethod.tunnelLowFlows:
             if len(flow) == 5:
                 testMethod.tunnelLowUse -= flow[1]
                 testMethod.tunnelLowSum -= flow[0]
-                testMethod.tunnelLowFlows.remove(flow)
-
+                oldFlows.append(flow)
+        for flow in oldFlows:
+            testMethod.tunnelLowFlows.remove(flow)
 
     def queueAllocation(self, testMethod): 
         testMethod.schedulerData[3] = 0
-
-        sum_teste = 0
 
         for flow in testMethod.schedulerData[2]:
             if len(flow) == 4:
@@ -74,19 +78,13 @@ class MethodsSimulator:
                     testMethod.schedulerData[3] += flow[1]
                     continue
 
-            sum_teste += flow[1]
-
-            print(flow[4])
-
             if isinstance(testMethod, DeMONS):
                 testMethod.selectiveFlowAllocation(flow[2], flow[0], flow[1], flow[3], flow[4])
             elif isinstance(testMethod, VGuard):
                 testMethod.flowAllocation(flow[2], flow[0], flow[1], flow[3], flow[4])
 
         testMethod.schedulerData[1] = 0
-        testMethod.schedulerData[2] = []  
-        print("---> ", sum_teste)
-
+        testMethod.schedulerData[2] = []
 
     def lowTunnelSatisfaction(self, testMethod):
         if testMethod.tunnelLowUse != 0:
@@ -337,19 +335,9 @@ class MethodsSimulator:
                         outputFile.write('\nSecond: ' + str(seconds) + ' Traffic: ' + str(data.replace('\n', '')) + "\n")
                     seconds += 1
                 else:
-
-                    print(testMethod.tunnelLowUse)
-                    print(testMethod.tunnelHighUse, "\n--")
-
+                    
                     #Inserting flows from the queue into the low-priority tunnel to compete for resources
                     self.queueAllocation(testMethod)
-
-                    if seconds == 4:
-                        self.removeDeadFlows(testMethod)
-
-                        print(testMethod.tunnelLowUse)
-                        print(testMethod.tunnelHighUse, "\n")
-                        exit()
 
                     nonQueuedData = len(testMethod.tunnelLowFlows)
                     testMethod.tunnelLowFilter(filterMechanism, filterPolicy)

--- a/Solutions/Filters.py
+++ b/Solutions/Filters.py
@@ -189,6 +189,7 @@ def leakyBucketPriorityShapper(testMethod, rate, policy):
 				dropFactor = 1-flow[0]
 			if dropFactor > 1:
 				dropFactor = 1
+
 			queueFactor = (1 - dropFactor)
 			flowDrop = math.floor(flow[1] * dropFactor)
 


### PR DESCRIPTION
Solving a queue problem: Old flows were not being removed as expected (only half of the old flows were actually being removed). This occurred because flows were being removed inside the iteration loop, which altered the size of the flow list dynamically. Moving the removal to after the loop resolved the issue.